### PR TITLE
add support for `APIGatewayProxyRequestContext`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/apex/gateway"
+	"github.com/aws/aws-lambda-go"
 )
 
 func main() {
@@ -21,7 +22,11 @@ func main() {
 }
 
 func hello(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, "Hello World from Go")
+	// example retrieving values from the api gateway proxy request context.
+	requestContext := gateway.RequestContext(r.Context())
+	userID := requestContext.Authorizer["sub"].(string)
+
+	fmt.Fprintf(w, "Hello %s from Go", userID)
 }
 ```
 

--- a/Readme.md
+++ b/Readme.md
@@ -23,9 +23,12 @@ func main() {
 
 func hello(w http.ResponseWriter, r *http.Request) {
 	// example retrieving values from the api gateway proxy request context.
-	requestContext := gateway.RequestContext(r.Context())
-	userID := requestContext.Authorizer["sub"].(string)
+	requestContext, ok := gateway.RequestContext(r.Context())
+	if !ok || requestContext.Authorizer["sub"] == nil {
+		fmt.Fprint(w, "Hello World from Go")
+	}
 
+	userID := requestContext.Authorizer["sub"].(string)
 	fmt.Fprintf(w, "Hello %s from Go", userID)
 }
 ```

--- a/context.go
+++ b/context.go
@@ -1,0 +1,24 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// key is the type used for any items added to the request context.
+type key int
+
+// requestContextKey is the key for the api gateway proxy `RequestContext`.
+const requestContextKey key = iota
+
+// newContext returns a new Context with specific api gateway proxy values.
+func newContext(ctx context.Context, e events.APIGatewayProxyRequest) context.Context {
+	return context.WithValue(ctx, requestContextKey, e.RequestContext)
+}
+
+// RequestContext returns the APIGatewayProxyRequestContext value stored in ctx.
+func RequestContext(ctx context.Context) (events.APIGatewayProxyRequestContext, bool) {
+	c, ok := ctx.Value(requestContextKey).(events.APIGatewayProxyRequestContext)
+	return c, ok
+}

--- a/request.go
+++ b/request.go
@@ -59,6 +59,9 @@ func NewRequest(e events.APIGatewayProxyRequest) (*http.Request, error) {
 	req.Header.Set("X-Request-Id", e.RequestContext.RequestID)
 	req.Header.Set("X-Stage", e.RequestContext.Stage)
 
+	// custom context values
+	req = req.WithContext(newContext(req.Context(), e))
+
 	// host
 	req.URL.Host = req.Header.Get("Host")
 	req.Host = req.URL.Host


### PR DESCRIPTION
This would be useful to get access to more values from the context, for instance when using api gateway authorizers.

Another option would be to json serialize the context and pass it as a header. I'm not sure what would be preferable?