### PR TITLE
Ignore charset parameter when checking if content type is text

### DIFF
--- a/response.go
+++ b/response.go
@@ -82,7 +82,8 @@ func (w *ResponseWriter) End() events.APIGatewayProxyResponse {
 
 // isBinary returns true if the response reprensents binary.
 func isBinary(h http.Header) bool {
-	if !isTextMime(h.Get("Content-Type")) {
+	contentType := strings.Split(h.Get("Content-Type"), ";")[0]
+	if !isTextMime(contentType) {
 		return true
 	}
 


### PR DESCRIPTION
Thanks for the library - works great! I just noticed I was getting base64 encoded responses when I didn't expect it due to the charset parameter in the content type breaking the check for text mime types. This PR strips off the charset param before doing the check.