### PR TITLE
fix(Response) Fix for autodetect text mime types.

### DIFF
--- a/response.go
+++ b/response.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"bytes"
 	"encoding/base64"
+	"mime"
 	"net/http"
 	"strings"
 
@@ -95,14 +96,21 @@ func isBinary(h http.Header) bool {
 
 // isTextMime returns true if the content type represents textual data.
 func isTextMime(kind string) bool {
-	switch {
-	case strings.HasSuffix(kind, "svg+xml"):
+	mt, _, err := mime.ParseMediaType(kind)
+	if err != nil {
+		return false
+	}
+
+	if strings.HasPrefix(mt, "text/") {
 		return true
-	case strings.HasPrefix(kind, "text/"):
+	}
+
+	switch mt {
+	case "svg+xml":
 		return true
-	case strings.HasPrefix(kind, "application/") && strings.HasSuffix(kind, "json"):
+	case "application/json":
 		return true
-	case strings.HasPrefix(kind, "application/") && strings.HasSuffix(kind, "xml"):
+	case "application/xml":
 		return true
 	default:
 		return false

--- a/response_test.go
+++ b/response_test.go
@@ -1,0 +1,19 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_JSON_isTextMime(t *testing.T) {
+	assert.Equal(t, isTextMime("application/json"), true)
+	assert.Equal(t, isTextMime("application/json; charset=utf-8"), true)
+	assert.Equal(t, isTextMime("Application/JSON"), true)
+}
+
+func Test_XML_isTextMime(t *testing.T) {
+	assert.Equal(t, isTextMime("application/xml"), true)
+	assert.Equal(t, isTextMime("application/xml; charset=utf-8"), true)
+	assert.Equal(t, isTextMime("ApPlicaTion/xMl"), true)
+}


### PR DESCRIPTION
The original code returned base64 content when https://github.com/gin-gonic/gin provided the following mime type `application/json; charset=utf-8` for JSON.

This fix works based on my testing, interested to hear your thoughts on using the inbuilt `mime` package for parsing.

* Changed matching to allow for trailing encoding.
* Added a test case for the updated function.