### PR TITLE
feat(Response) Add CloseNotify support.

### DIFF
--- a/response_test.go
+++ b/response_test.go
@@ -52,6 +52,7 @@ func TestResponseWriter_Write_text(t *testing.T) {
 			assert.Equal(t, "hello world\n", e.Body)
 			assert.Equal(t, kind, e.Headers["Content-Type"])
 			assert.False(t, e.IsBase64Encoded)
+			assert.True(t, <-w.CloseNotify())
 		})
 	}
 }


### PR DESCRIPTION
This is required to use `httputils.ReverseProxy` and enable proxying of requests otherwise it returns the following error:

> *gateway.ResponseWriter is not http.CloseNotifier: missing method CloseNotify

It is used with `context.Context` to interupt in flight requests when the response is ended.