### PR TITLE
Add stage path to request path if api gateway host

### DIFF
--- a/request.go
+++ b/request.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const apiHostSuffix = ".amazonaws.com"
+
 // NewRequest returns a new http.Request from the given Lambda event.
 func NewRequest(ctx context.Context, e events.APIGatewayProxyRequest) (*http.Request, error) {
 	// path
@@ -69,6 +71,11 @@ func NewRequest(ctx context.Context, e events.APIGatewayProxyRequest) (*http.Req
 	// host
 	req.URL.Host = req.Header.Get("Host")
 	req.Host = req.URL.Host
+
+	// add stage to path
+	if strings.HasSuffix(req.Host, apiHostSuffix) {
+		req.URL.Path = "/" + e.RequestContext.Stage + req.URL.Path
+	}
 
 	return req, nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -127,3 +127,29 @@ func TestNewRequest_bodyBinary(t *testing.T) {
 
 	assert.Equal(t, "hello world\n", string(b))
 }
+
+func TestNewRequest_apiHostname(t *testing.T) {
+	e := events.APIGatewayProxyRequest{
+		HTTPMethod: "POST",
+		Path:       "/pets",
+		Body:       `{ "name": "Tobi" }`,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+			"Host":         "1234567890.execute-api.us-east-1.amazonaws.com",
+		},
+		RequestContext: events.APIGatewayProxyRequestContext{
+			RequestID: "1234",
+			Stage:     "prod",
+		},
+	}
+
+	r, err := NewRequest(context.Background(), e)
+	assert.NoError(t, err)
+
+	assert.Equal(t, `1234567890.execute-api.us-east-1.amazonaws.com`, r.Host)
+	assert.Equal(t, `prod`, r.Header.Get("X-Stage"))
+	assert.Equal(t, `1234`, r.Header.Get("X-Request-Id"))
+	assert.Equal(t, `18`, r.Header.Get("Content-Length"))
+	assert.Equal(t, `application/json`, r.Header.Get("Content-Type"))
+	assert.Equal(t, `/prod/pets`, r.URL.Path)
+}


### PR DESCRIPTION
url: `https://1234567890.execute-api.us-east-1.amazonaws.com/prod/pets`
expected path: `/prod/pets`
actual path: `/pets`

This will add the stage path part to the request url path if the host is an aws api gateway host.