### PR TITLE
Remove brackets on license to support linting tools

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-(The MIT License)
+The MIT License
 
 Copyright (c) 2018 TJ Holowaychuk tj@tjholowaychuk.com
 


### PR DESCRIPTION
linting tools such as 

https://github.com/frapposelli/wwhrd

are unable to parse your License file because of the brackets
