### PR TITLE
Pass-through incoming ctx to Request

### DIFF
--- a/request.go
+++ b/request.go
@@ -62,7 +62,7 @@ func NewRequest(ctx context.Context, e events.APIGatewayProxyRequest) (*http.Req
 	req.Header.Set("X-Stage", e.RequestContext.Stage)
 
 	// custom context values
-	req = req.WithContext(newContext(req.Context(), e))
+	req = req.WithContext(newContext(ctx, e))
 
 	// xray support
 	if traceID := ctx.Value("x-amzn-trace-id"); traceID != nil {

--- a/request_test.go
+++ b/request_test.go
@@ -127,3 +127,12 @@ func TestNewRequest_bodyBinary(t *testing.T) {
 
 	assert.Equal(t, "hello world\n", string(b))
 }
+
+func TestNewRequest_context(t *testing.T) {
+	e := events.APIGatewayProxyRequest{}
+	ctx := context.WithValue(context.Background(), "key", "value")
+	r, err := NewRequest(ctx, e)
+	assert.NoError(t, err)
+	v := r.Context().Value("key")
+	assert.Equal(t, "value", v)
+}


### PR DESCRIPTION
Hi there!

This fixes what I think is a bug in passing-through the incoming `ctx` value to the created `Request`. Without this fix, the incoming `ctx` is lost, so for instance the values that are set by https://github.com/aws/aws-lambda-go are lost and you can't use `lambdacontext.FromContext(r.Context())` to get the lambda context info back.