### PR TITLE
Added support for multiple header value in API Gateway

### DIFF
--- a/response.go
+++ b/response.go
@@ -58,14 +58,18 @@ func (w *ResponseWriter) WriteHeader(status int) {
 	w.out.StatusCode = status
 
 	h := make(map[string]string)
+	mvh := make(map[string][]string)
 
 	for k, v := range w.Header() {
-		if len(v) > 0 {
-			h[k] = v[len(v)-1]
+		if len(v) == 1 {
+			h[k] = v[0]
+		} else if len(v) > 1 {
+			mvh[k] = v
 		}
 	}
 
 	w.out.Headers = h
+	w.out.MultiValueHeaders = mvh
 	w.wroteHeader = true
 }
 


### PR DESCRIPTION
Last October AWS [announced support for multi-value headers](https://aws.amazon.com/fr/about-aws/whats-new/2018/10/amazon-api-gateway-adds-support-for-multi-parameters/).

Since version [1.8.1](https://github.com/aws/aws-lambda-go/tree/v1.8.1), `aws-lambda-go` package events supports multi-value headers as `map[string][]string`.

This is particularly useful for setting multiple cookies. This is a quick fix proposal.
