### PR TITLE
Remove unnecessary import in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,6 @@ import (
 	"os"
 
 	"github.com/apex/gateway"
-	"github.com/aws/aws-lambda-go"
 )
 
 func main() {


### PR DESCRIPTION
Hey,
the import of the aws-lambda-go is 

a) Broken. Because it's missing a `/lambda` at the end
and 
b) Unnecessary for the example and go build will complain.

So I removed it ;) This also 'fixes' the problem in  #22 

Best regards,
Felix