### PR TITLE
Add application/javascript as text mime type

### DIFF
--- a/response.go
+++ b/response.go
@@ -118,11 +118,7 @@ func isTextMime(kind string) bool {
 	}
 
 	switch mt {
-	case "image/svg+xml":
-		return true
-	case "application/json":
-		return true
-	case "application/xml":
+	case "image/svg+xml", "application/json", "application/xml","application/javascript":
 		return true
 	default:
 		return false


### PR DESCRIPTION
`application/javascript` is a text mime type, added condition for that.