### PR TITLE
Add GetRequest

### DIFF
--- a/request.go
+++ b/request.go
@@ -50,7 +50,7 @@ func NewRequest(ctx context.Context, e events.APIGatewayProxyRequest) (*http.Req
 
 	// manually set RequestURI because NewRequest is for clients and req.RequestURI is for servers
 	req.RequestURI = e.Path
-	
+
 	// remote addr
 	req.RemoteAddr = e.RequestContext.Identity.SourceIP
 

--- a/request_test.go
+++ b/request_test.go
@@ -56,8 +56,8 @@ func TestNewRequest_multiValueQueryString(t *testing.T) {
 		HTTPMethod: "GET",
 		Path:       "/pets",
 		MultiValueQueryStringParameters: map[string][]string{
-			"multi_fields": []string{"name", "species"},
-			"multi_arr[]":  []string{"arr1", "arr2"},
+			"multi_fields": {"name", "species"},
+			"multi_arr[]":  {"arr1", "arr2"},
 		},
 		QueryStringParameters: map[string]string{
 			"order":  "desc",
@@ -123,8 +123,8 @@ func TestNewRequest_multiHeader(t *testing.T) {
 		Path:       "/pets",
 		Body:       `{ "name": "Tobi" }`,
 		MultiValueHeaders: map[string][]string{
-			"X-APEX":   []string{"apex1", "apex2"},
-			"X-APEX-2": []string{"apex-1", "apex-2"},
+			"X-APEX":   {"apex1", "apex2"},
+			"X-APEX-2": {"apex-1", "apex-2"},
 		},
 		Headers: map[string]string{
 			"Content-Type": "application/json",

--- a/response.go
+++ b/response.go
@@ -118,7 +118,7 @@ func isTextMime(kind string) bool {
 	}
 
 	switch mt {
-	case "image/svg+xml", "application/json", "application/xml","application/javascript":
+	case "image/svg+xml", "application/json", "application/xml", "application/javascript":
 		return true
 	default:
 		return false

--- a/v2/context.go
+++ b/v2/context.go
@@ -9,16 +9,25 @@ import (
 // key is the type used for any items added to the request context.
 type key int
 
-// requestContextKey is the key for the api gateway proxy `RequestContext`.
+// requestContextKey is the key for the api gateway proxy `Request`.
 const requestContextKey key = iota
 
 // RequestContext returns the APIGatewayV2HTTPRequestContext value stored in ctx.
 func RequestContext(ctx context.Context) (events.APIGatewayV2HTTPRequestContext, bool) {
-	c, ok := ctx.Value(requestContextKey).(events.APIGatewayV2HTTPRequestContext)
+	c, ok := GetRequest(ctx)
+	if ok {
+		return c.RequestContext, true
+	}
+	return events.APIGatewayV2HTTPRequestContext{}, false
+}
+
+// GetRequest returns the APIGatewayV2HTTPRequest value stored in ctx.
+func GetRequest(ctx context.Context) (events.APIGatewayV2HTTPRequest, bool) {
+	c, ok := ctx.Value(requestContextKey).(events.APIGatewayV2HTTPRequest)
 	return c, ok
 }
 
 // newContext returns a new Context with specific api gateway v2 values.
 func newContext(ctx context.Context, e events.APIGatewayV2HTTPRequest) context.Context {
-	return context.WithValue(ctx, requestContextKey, e.RequestContext)
+	return context.WithValue(ctx, requestContextKey, e)
 }


### PR DESCRIPTION
# /v2

It's extremely useful to have access to the original object

Its `QueryStringParameters` are not stored to the request's URL ones with the default implementation (is it a Bug?) so we need access through the original lambda request. I did create an application with google forms + aws/apex + [iris](https://iris-go.com) + [netlify functions](https://docs.netlify.com/functions/overview/) and I had to modify the source in order for that to work. This is a simple PR which makes the `APIGatewayV2HTTPRequest` available to the backend developer, no breaking changes as the context key was unexported.

EDIT: for some reason the Semaphoreci is failed, but the tests are running just fine:

```sh
PS C:\mygopath\src\github.com\kataras\gateway> go test -v ./...
=== RUN   TestNewRequest_path
--- PASS: TestNewRequest_path (0.00s)
=== RUN   TestNewRequest_method
--- PASS: TestNewRequest_method (0.00s)
=== RUN   TestNewRequest_queryString
--- PASS: TestNewRequest_queryString (0.00s)
=== RUN   TestNewRequest_multiValueQueryString
--- PASS: TestNewRequest_multiValueQueryString (0.00s)
=== RUN   TestNewRequest_remoteAddr
--- PASS: TestNewRequest_remoteAddr (0.00s)
=== RUN   TestNewRequest_header
--- PASS: TestNewRequest_header (0.00s)
=== RUN   TestNewRequest_multiHeader
--- PASS: TestNewRequest_multiHeader (0.00s)
=== RUN   TestNewRequest_body
--- PASS: TestNewRequest_body (0.00s)
=== RUN   TestNewRequest_bodyBinary
--- PASS: TestNewRequest_bodyBinary (0.00s)
=== RUN   TestNewRequest_context
--- PASS: TestNewRequest_context (0.00s)
=== RUN   Test_JSON_isTextMime
--- PASS: Test_JSON_isTextMime (0.00s)
=== RUN   Test_XML_isTextMime
--- PASS: Test_XML_isTextMime (0.00s)
=== RUN   TestResponseWriter_Header
--- PASS: TestResponseWriter_Header (0.00s)
=== RUN   TestResponseWriter_multiHeader
--- PASS: TestResponseWriter_multiHeader (0.00s)
=== RUN   TestResponseWriter_Write_text
=== RUN   TestResponseWriter_Write_text/text/x-custom
=== RUN   TestResponseWriter_Write_text/text/plain
=== RUN   TestResponseWriter_Write_text/text/plain;_charset=utf-8
=== RUN   TestResponseWriter_Write_text/application/json
=== RUN   TestResponseWriter_Write_text/application/json;_charset=utf-8
=== RUN   TestResponseWriter_Write_text/application/xml
=== RUN   TestResponseWriter_Write_text/image/svg+xml
--- PASS: TestResponseWriter_Write_text (0.00s)
    --- PASS: TestResponseWriter_Write_text/text/x-custom (0.00s)
    --- PASS: TestResponseWriter_Write_text/text/plain (0.00s)
    --- PASS: TestResponseWriter_Write_text/text/plain;_charset=utf-8 (0.00s)
    --- PASS: TestResponseWriter_Write_text/application/json (0.00s)
    --- PASS: TestResponseWriter_Write_text/application/json;_charset=utf-8 (0.00s)
    --- PASS: TestResponseWriter_Write_text/application/xml (0.00s)
    --- PASS: TestResponseWriter_Write_text/image/svg+xml (0.00s)
=== RUN   TestResponseWriter_Write_binary
--- PASS: TestResponseWriter_Write_binary (0.00s)
=== RUN   TestResponseWriter_Write_gzip
--- PASS: TestResponseWriter_Write_gzip (0.00s)
=== RUN   TestResponseWriter_WriteHeader
--- PASS: TestResponseWriter_WriteHeader (0.00s)
=== RUN   TestGateway_Invoke
--- PASS: TestGateway_Invoke (0.00s)
PASS
ok      github.com/apex/gateway 0.323s
```

/CC @wolfeidau 