### PR TITLE
Enable gateway to work with Application Load Balancer with Multi Value Headers enabled

### DIFF
--- a/request.go
+++ b/request.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strconv"
 	"strings"
@@ -60,7 +61,7 @@ func NewRequest(ctx context.Context, e events.APIGatewayProxyRequest) (*http.Req
 	}
 
 	for k, values := range e.MultiValueHeaders {
-		req.Header[k] = values
+		req.Header[textproto.CanonicalMIMEHeaderKey(k)] = values
 	}
 
 	// content-length

--- a/response.go
+++ b/response.go
@@ -63,6 +63,7 @@ func (w *ResponseWriter) WriteHeader(status int) {
 	for k, v := range w.Header() {
 		if len(v) == 1 {
 			h[k] = v[0]
+			mvh[k] = v
 		} else if len(v) > 1 {
 			mvh[k] = v
 		}


### PR DESCRIPTION
We have been using gateway with go-gin and recently swapped from using an API Gateway to an ALB for routing, which worked fine. However, when trying to turn multi value headers on the site broke when run through gateway.
I have discovered that the multi value headers were being set with lower case header names, which was not being picked up using Header.Get, and that the ALB expects all header values to be returned in the multi value headers when using this mode.

My testing suggests that this should not break anything when running without multi value headers enabled as before.