### PR TITLE
Treat JSON API responses as the text they are

### DIFF
--- a/response.go
+++ b/response.go
@@ -118,7 +118,7 @@ func isTextMime(kind string) bool {
 	}
 
 	switch mt {
-	case "image/svg+xml", "application/json", "application/xml","application/javascript":
+	case "image/svg+xml", "application/json", "application/xml", "application/javascript", "application/vnd.api+json":
 		return true
 	default:
 		return false

--- a/response_test.go
+++ b/response_test.go
@@ -13,6 +13,12 @@ func Test_JSON_isTextMime(t *testing.T) {
 	assert.Equal(t, isTextMime("Application/JSON"), true)
 }
 
+func Test_JSONAPI_isTextMime(t *testing.T) {
+	assert.Equal(t, isTextMime("application/vnd.api+json"), true)
+	assert.Equal(t, isTextMime("application/vnd.api+json; charset=utf-8"), true)
+	assert.Equal(t, isTextMime("Application/VND.API+JSON"), true)
+}
+
 func Test_XML_isTextMime(t *testing.T) {
 	assert.Equal(t, isTextMime("application/xml"), true)
 	assert.Equal(t, isTextMime("application/xml; charset=utf-8"), true)


### PR DESCRIPTION
The content-type "application/vnd.api/json" is a text based JSON
response type. Lets treat it as such.

Refernce: https://jsonapi.org/format/